### PR TITLE
api-v1-item

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -254,7 +254,60 @@ paths:
         "500":
           $ref: "#/components/responses/ServerError"
 
-  ####################### Ownership API #######################
+  /v1/items/byOwners:
+    post:
+      tags:
+        - item-controller
+      description: "Returns all items that match the search criteria, searchable by owner"
+      operationId: searchItemByhOwners
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ItemByOwnersSearchForm"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Items"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/EntityNotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /v1/items/{itemId}/owners:
+    get:
+      tags:
+        - item-controller
+      description: "Returns an item with a list of its owners"
+      operationId: getItemWithOwners
+      parameters:
+        - name: "itemId"
+          in: path
+          required: true
+          description: "Item Id, has format `${blockchain}:${token}:${tokenId}`"
+          schema:
+            $ref: "#/components/schemas/ItemId"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Item"
+                  - $ref: "#/components/schemas/ItemOwners"
+        '400':
+          $ref: "#/components/responses/BadRequest"
+        '500':
+          $ref: "#/components/responses/ServerError"
+
+
+      ####################### Ownership API #######################
 
   /v0.1/ownerships/{ownershipId}:
     get:
@@ -923,6 +976,62 @@ components:
                 value:
                   $ref: "#/components/schemas/SearchBigDecimal"
 
+    ItemByOwnersSearchForm:
+      type: object
+      properties:
+        cursor:
+          default: null
+          description: "Combined continuation token to paginate activities search result"
+          type: string
+        blockchains:
+          default: []
+          description: "Type of the blockchain network"
+          type: array
+          items:
+            $ref: "#/components/schemas/Blockchain"
+        owners:
+          default: []
+          description: "Owners addresses, has format `${blockchainType}:${address}`"
+          type: array
+          items:
+            $ref: "#/components/schemas/Address"
+        collections:
+          default: []
+          description: "Collection Id, has format `${blockchain}:${nativeICollectionId}`"
+          type: array
+          items:
+            $ref: "#/components/schemas/CollectionId"
+        mintedAt:
+          $ref: "#/components/schemas/SearchDate"
+        lastUpdatedAt:
+          $ref: "#/components/schemas/SearchDate"
+        text:
+          description: "The search string parameter, search by name anf description of the item"
+          type: string
+        trait:
+          type: array
+          items:
+            $ref: "#/components/schemas/ItemsTrait"
+        sale:
+          default: null
+          description: "An object that describes the parameters for searching for items based on information about sell orders"
+          type: object
+          properties:
+            totalStock:
+              $ref: "#/components/schemas/SearchBigInteger"
+            sellers:
+              $ref: "#/components/schemas/SearchBigInteger"
+            priceUsd:
+              $ref: "#/components/schemas/SearchBigDecimal"
+            price:
+              default: null
+              description: "An object that allows you to search for orders in a given currency"
+              type: object
+              properties:
+                currency:
+                  $ref: "#/components/schemas/CurrencyId"
+                value:
+                  $ref: "#/components/schemas/SearchBigDecimal"
 
     ItemsTrait:
       type: object
@@ -988,6 +1097,20 @@ components:
             $ref: "#/components/schemas/Item"
       required:
         - items
+
+    ItemOwner:
+      type: object
+      properties:
+        owner:
+          $ref: "#/components/schemas/Address"
+        quantity:
+          $ref: "#/components/schemas/BigInteger"
+
+    ItemOwners:
+      type: object
+      properties:
+        itemOwners:
+          $ref: "#/components/schemas/ItemOwner"
 
     ItemsWithOwnership:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -892,11 +892,7 @@ components:
             items:
               $ref: "#/components/schemas/SearchBigInteger"
         creator:
-          default: []
-          description: "Item creator's address"
-          type: array
-          items:
-            $ref: "#/components/schemas/Address"
+          $ref: "#/components/schemas/Address"
         lazySupply:
           $ref: "#/components/schemas/SearchBigInteger"
         supply:
@@ -906,20 +902,12 @@ components:
         lastUpdatedAt:
           $ref: "#/components/schemas/SearchDate"
         text:
-          default: null
-          description: "The search string parameter"
+          description: "The search string parameter, search by name anf description of the item"
           type: string
-        textSearchOptions:
-          default: null
-          description: "For full-text search in items, you can search by: name, description, attributes. 
-                 Leave this field blank to search across all parameters."
-          example: "null, [name, description, ], []"
+        trait:
           type: array
           items:
-            default: null
-            description: "Available values: name, description, attributes"
-            example: "name, description, attributes"
-            type: string
+            $ref: "#/components/schemas/ItemsTrait"
         metaContent:
           default: null
           description: "An object describing the parameters for searching for items by meta content"
@@ -950,6 +938,16 @@ components:
               $ref: "#/components/schemas/SearchBigInteger"
             priceUsd:
               $ref: "#/components/schemas/SearchBigDecimal"
+
+    ItemsTrait:
+      type: object
+      properties:
+        key:
+          type: string
+        values:
+          type: array
+          items:
+            type: string
 
     ItemLastSale:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -229,7 +229,7 @@ paths:
         '500':
           $ref: "#/components/responses/ServerError"
 
-  /v1/items/:
+  /v1/items:
     post:
       tags:
         - item-controller
@@ -873,24 +873,18 @@ components:
           default: null
           description: "Combined continuation token to paginate activities search result"
           type: string
-        blockchain:
+        blockchains:
           default: []
           description: "Type of the blockchain network"
           type: array
           items:
             $ref: "#/components/schemas/Blockchain"
-        collection:
+        collections:
           default: []
           description: "Collection Id, has format `${blockchain}:${nativeICollectionId}`"
           type: array
           items:
             $ref: "#/components/schemas/CollectionId"
-        tokenId:
-          default: []
-            description: "Token Id"
-            type: array
-            items:
-              $ref: "#/components/schemas/SearchBigInteger"
         creator:
           $ref: "#/components/schemas/Address"
         lazySupply:
@@ -908,25 +902,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ItemsTrait"
-        metaContent:
-          default: null
-          description: "An object describing the parameters for searching for items by meta content"
-          type: object
-          properties:
-            type:
-              default: null
-              description: "The type of content contained in the item"
-              example: "IMAGE/VIDEO/AUDIO/MODEL_3D/HTML"
-              type: array
-              items:
-                type: string
-            mimeType:
-              default: null
-              description: "The MIME type (RFC 6838) of content contained in the item"
-              example: "image/png"
-              type: array
-              items:
-                type: string
         sale:
           default: null
           description: "An object that describes the parameters for searching for items based on information about sell orders"
@@ -938,6 +913,16 @@ components:
               $ref: "#/components/schemas/SearchBigInteger"
             priceUsd:
               $ref: "#/components/schemas/SearchBigDecimal"
+            price:
+              default: null
+              description: "An object that allows you to search for orders in a given currency"
+              type: object
+              properties:
+                currency:
+                  $ref: "#/components/schemas/CurrencyId"
+                value:
+                  $ref: "#/components/schemas/SearchBigDecimal"
+
 
     ItemsTrait:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -229,12 +229,12 @@ paths:
         '500':
           $ref: "#/components/responses/ServerError"
 
-  /v1/items/search:
+  /v1/items/:
     post:
       tags:
         - item-controller
       description: "Returns all items that match the search criteria"
-      operationId: itemSearch
+      operationId: searchItems
       requestBody:
         content:
           application/json:
@@ -905,29 +905,21 @@ components:
           $ref: "#/components/schemas/SearchDate"
         lastUpdatedAt:
           $ref: "#/components/schemas/SearchDate"
-        meta:
+        text:
           default: null
-          description: "An object describing the parameters for searching for items by meta-information"
-          type: object
-          properties:
-            name:
-              default: null
-              description: "Item name"
-              type: array
-              items:
-                type: string
-            description:
-              default: null
-              description: "Item description"
-              type: array
-              items:
-                type: string
-            attribute:
-              default: null
-              description: "Item attributes"
-              type: array
-              items:
-                $ref: "#/components/schemas/MetaAttribute"
+          description: "The search string parameter"
+          type: string
+        textSearchOptions:
+          default: null
+          description: "For full-text search in items, you can search by: name, description, attributes. 
+                 Leave this field blank to search across all parameters."
+          example: "null, [name, description, ], []"
+          type: array
+          items:
+            default: null
+            description: "Available values: name, description, attributes"
+            example: "name, description, attributes"
+            type: string
         metaContent:
           default: null
           description: "An object describing the parameters for searching for items by meta content"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -205,10 +205,10 @@ paths:
           description: "Type of the blockchain network"
           schema:
             $ref: "#/components/schemas/Blockchain"
-        - name: "continuation"
+        - name: "cursor"
           in: query
           required: false
-          description: "Continuation token from the previous response"
+          description: "Combined continuation token to paginate activities search result"
           schema:
             type: string
         - name: "size"
@@ -227,6 +227,31 @@ paths:
         '400':
           $ref: "#/components/responses/BadRequest"
         '500':
+          $ref: "#/components/responses/ServerError"
+
+  /v1/items/search:
+    post:
+      tags:
+        - item-controller
+      description: "Returns all items that match the search criteria"
+      operationId: itemSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ItemSearchForm"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Items"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/EntityNotFound"
+        "500":
           $ref: "#/components/responses/ServerError"
 
   ####################### Ownership API #######################
@@ -787,8 +812,6 @@ components:
           $ref: "#/components/schemas/Blockchain"
         collection:
           $ref: "#/components/schemas/CollectionId"
-        contract:
-          $ref: "#/components/schemas/ContractAddress"
         tokenId:
           $ref: "#/components/schemas/BigInteger"
         creators:
@@ -799,12 +822,6 @@ components:
             $ref: "#/components/schemas/Creator"
         lazySupply:
           $ref: "#/components/schemas/BigInteger"
-        pending:
-          type: array
-          description: "Pending information about the item"
-          default: [ ]
-          items:
-            $ref: "#/components/schemas/ItemTransfer"
         mintedAt:
           type: string
           format: date-time
@@ -849,6 +866,99 @@ components:
         - sellers
         - auctions
 
+    ItemSearchForm:
+      type: object
+      properties:
+        cursor:
+          default: null
+          description: "Combined continuation token to paginate activities search result"
+          type: string
+        blockchain:
+          default: []
+          description: "Type of the blockchain network"
+          type: array
+          items:
+            $ref: "#/components/schemas/Blockchain"
+        collection:
+          default: []
+          description: "Collection Id, has format `${blockchain}:${nativeICollectionId}`"
+          type: array
+          items:
+            $ref: "#/components/schemas/CollectionId"
+        tokenId:
+          default: []
+            description: "Token Id"
+            type: array
+            items:
+              $ref: "#/components/schemas/SearchBigInteger"
+        creator:
+          default: []
+          description: "Item creator's address"
+          type: array
+          items:
+            $ref: "#/components/schemas/Address"
+        lazySupply:
+          $ref: "#/components/schemas/SearchBigInteger"
+        supply:
+          $ref: "#/components/schemas/SearchBigInteger"
+        mintedAt:
+          $ref: "#/components/schemas/SearchDate"
+        lastUpdatedAt:
+          $ref: "#/components/schemas/SearchDate"
+        meta:
+          default: null
+          description: "An object describing the parameters for searching for items by meta-information"
+          type: object
+          properties:
+            name:
+              default: null
+              description: "Item name"
+              type: array
+              items:
+                type: string
+            description:
+              default: null
+              description: "Item description"
+              type: array
+              items:
+                type: string
+            attribute:
+              default: null
+              description: "Item attributes"
+              type: array
+              items:
+                $ref: "#/components/schemas/MetaAttribute"
+        metaContent:
+          default: null
+          description: "An object describing the parameters for searching for items by meta content"
+          type: object
+          properties:
+            type:
+              default: null
+              description: "The type of content contained in the item"
+              example: "IMAGE/VIDEO/AUDIO/MODEL_3D/HTML"
+              type: array
+              items:
+                type: string
+            mimeType:
+              default: null
+              description: "The MIME type (RFC 6838) of content contained in the item"
+              example: "image/png"
+              type: array
+              items:
+                type: string
+        sale:
+          default: null
+          description: "An object that describes the parameters for searching for items based on information about sell orders"
+          type: object
+          properties:
+            totalStock:
+              $ref: "#/components/schemas/SearchBigInteger"
+            sellers:
+              $ref: "#/components/schemas/SearchBigInteger"
+            priceUsd:
+              $ref: "#/components/schemas/SearchBigDecimal"
+
     ItemLastSale:
       type: object
       properties:
@@ -892,9 +1002,9 @@ components:
           type: integer
           format: int64
           description: "Number of items were found by request"
-        continuation:
+        cursor:
           type: string
-          description: "Continuation token to paginate items search result"
+          description: "Combined continuation token to paginate activities search result"
         items:
           type: array
           description: "List of found items"
@@ -3339,6 +3449,44 @@ components:
           $ref: "#/components/schemas/ContractAddress"
       required:
         - "@type"
+
+    #======================== Other – For Search ============================#
+
+    SearchDate:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date-time
+        operator:
+          $ref: "#/components/schemas/ComparisonOperator"
+
+    SearchBigDecimal:
+      type: object
+      properties:
+        value:
+          $ref: "#/components/schemas/BigDecimal"
+        operator:
+          $ref: "#/components/schemas/ComparisonOperator"
+
+    SearchBigInteger:
+      type: object
+      properties:
+        value:
+          $ref: "#/components/schemas/BigInteger"
+        operator:
+          $ref: "#/components/schemas/ComparisonOperator"
+
+    ComparisonOperator:
+      default: EQUAL
+      type: string
+      enum:
+        - EQUAL
+        - GREATER
+        - LESS
+        - GREATER_OR_EQUAL
+        - LESS_OR_EQUAL
+        - NOT_EQUAL
 
     #################### Subscription-related ####################
 


### PR DESCRIPTION
Add path – itemSearch:
1. Decided to leave tokenId, I understand that it is not in Solana, so that something can be found in Solana, you just need to skip it.
2. I did not add metaWidth/metaHight/metaSize to the metaContent object for searching. It seems to be redundant for the first stage.
3. Using the Sale object, you can find items on sale

In Item:
1. Removed pending, because we abandoned them and remove them.
2. Removed contract, because it is not in Solana.For all other blockchains, it is possible to use the attribute - collection.